### PR TITLE
refactor: getServerSideProps implimented

### DIFF
--- a/components/PokemonStats.tsx
+++ b/components/PokemonStats.tsx
@@ -1,8 +1,18 @@
 import { FC } from 'react';
-import { PokemonPageProps } from '../pages/[pokemon]';
+import { useSelector } from 'react-redux';
+import {
+  getPokemonInfoImage,
+  getPokemonInfoName,
+  getPokemonInfoStats,
+  getPokemonInfoTypes,
+} from '../store/selectors';
 
-const PokemonStats: FC<PokemonPageProps> = (props) => {
-  const { image, name, stats, types } = props.ssrPokemonInfo;
+const PokemonStats: FC = () => {
+  const image = useSelector(getPokemonInfoImage);
+  const name = useSelector(getPokemonInfoName);
+  const stats = useSelector(getPokemonInfoStats);
+  const types = useSelector(getPokemonInfoTypes);
+
   const pokemonTypes = types.map((type) => type.type.name);
   const pokemonStats = stats.map((pokeStat) => {
     const { base_stat, stat } = pokeStat;

--- a/pages/[pokemon].tsx
+++ b/pages/[pokemon].tsx
@@ -1,17 +1,10 @@
 import { NextPage, NextPageContext } from 'next';
 import { useRouter } from 'next/router';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { setPokemonInfo } from '../store/pokemonInfoSlice';
 import { useEffect } from 'react';
 import { getPokemonInfo } from '../apiCalls';
-import {
-  StatsType,
-  getPokemonInfoImage,
-  getPokemonInfoName,
-  getPokemonInfoStats,
-  getPokemonInfoTypes,
-} from '../store/selectors';
-import { fetchPokemonInfo } from '../store/actions';
+import { StatsType } from '../store/selectors';
 import { AppDispatch } from '../store/store';
 import PokemonStats from '../components/PokemonStats';
 
@@ -32,18 +25,10 @@ const PokemonPage: NextPage<PokemonPageProps> = (props) => {
   const { name } = ssrPokemonInfo;
   const router = useRouter();
   const dispatch = useDispatch<AppDispatch>();
-  const searchedPokemon = router.query.pokemon as 'string';
-
-  const pokemonInfoImage = useSelector(getPokemonInfoImage);
-  const pokemonInfoName = useSelector(getPokemonInfoName);
-  const pokemonInfoTypes = useSelector(getPokemonInfoTypes);
-  const pokemonInfoStats = useSelector(getPokemonInfoStats);
 
   useEffect(() => {
     if (name) {
       dispatch(setPokemonInfo(ssrPokemonInfo));
-    } else {
-      dispatch(fetchPokemonInfo(searchedPokemon));
     }
   }, []);
 
@@ -51,43 +36,21 @@ const PokemonPage: NextPage<PokemonPageProps> = (props) => {
     router.push('/');
   };
 
-  // Handles the initial loading of the app
-  if (ssrPokemonInfo.name) {
-    return (
-      <div className='max-w-3xl mx-auto'>
-        <button
-          className='bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 border border-blue-700 rounded m-4'
-          onClick={onButtonClick}>
-          Back to Home
-        </button>
-        <PokemonStats ssrPokemonInfo={ssrPokemonInfo} />
-      </div>
-    );
-  }
-  // Handles Client side routing changes
-  if (pokemonInfoImage) {
-    const pokemonInfo: PokemonInfo = {
-      image: pokemonInfoImage,
-      name: pokemonInfoName,
-      types: pokemonInfoTypes,
-      stats: pokemonInfoStats,
-    };
-    return (
-      <div className='max-w-3xl mx-auto'>
-        <button
-          className='bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 border border-blue-700 rounded m-4'
-          onClick={onButtonClick}>
-          Back to Home
-        </button>
-        <PokemonStats ssrPokemonInfo={pokemonInfo} />
-      </div>
-    );
-  }
+  return (
+    <div className='max-w-3xl mx-auto'>
+      <button
+        className='bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 border border-blue-700 rounded m-4'
+        onClick={onButtonClick}>
+        Back to Home
+      </button>
+      <PokemonStats ssrPokemonInfo={ssrPokemonInfo} />
+    </div>
+  );
 };
 
 export default PokemonPage;
 
-PokemonPage.getInitialProps = async (ctx: NextPageContext) => {
+export const getServerSideProps = async (ctx: NextPageContext) => {
   const { query, req } = ctx;
   const searchedPokemon = query.pokemon;
 
@@ -108,6 +71,8 @@ PokemonPage.getInitialProps = async (ctx: NextPageContext) => {
       : [];
 
   return {
-    ssrPokemonInfo,
+    props: {
+      ssrPokemonInfo,
+    },
   };
 };

--- a/pages/[pokemon].tsx
+++ b/pages/[pokemon].tsx
@@ -4,22 +4,16 @@ import { useDispatch } from 'react-redux';
 import { setPokemonInfo } from '../store/pokemonInfoSlice';
 import { useEffect } from 'react';
 import { getPokemonInfo } from '../apiCalls';
-import { StatsType } from '../store/selectors';
 import { AppDispatch } from '../store/store';
 import PokemonStats from '../components/PokemonStats';
+import { PokemonInfo } from '../types/types';
 
-interface PokemonInfo {
-  image: string;
-  name: string;
-  stats: { base_stat: number; stat: { name: string } }[] | StatsType[];
-  types: { type: { name: string } }[] | string[];
-}
-
+// Interfaces
 export interface PokemonPageProps {
   ssrPokemonInfo: PokemonInfo;
-  rtkPokemonInfo?: PokemonInfo;
 }
 
+// Functional Component- Default export
 const PokemonPage: NextPage<PokemonPageProps> = (props) => {
   const { ssrPokemonInfo } = props;
   const { name } = ssrPokemonInfo;
@@ -43,13 +37,12 @@ const PokemonPage: NextPage<PokemonPageProps> = (props) => {
         onClick={onButtonClick}>
         Back to Home
       </button>
-      <PokemonStats ssrPokemonInfo={ssrPokemonInfo} />
+      <PokemonStats />
     </div>
   );
 };
 
-export default PokemonPage;
-
+// Server Side Rendering Logic
 export const getServerSideProps = async (ctx: NextPageContext) => {
   const { query, req } = ctx;
   const searchedPokemon = query.pokemon;
@@ -76,3 +69,5 @@ export const getServerSideProps = async (ctx: NextPageContext) => {
     },
   };
 };
+
+export default PokemonPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,11 +2,9 @@ import { useEffect } from 'react';
 import type { NextPage } from 'next';
 import styles from '../styles/Home.module.css';
 import { setInitialPokemon } from '../store/pokemonSlice';
-import { useDispatch, useSelector } from 'react-redux';
-import { getInitialPokemon } from '../store/selectors';
+import { useDispatch } from 'react-redux';
 import Link from 'next/link';
 import { getAllPokemon } from '../apiCalls';
-import { fetchInitialPokemon } from '../store/actions';
 import { AppDispatch } from '../store/store';
 
 interface HomeProps {
@@ -17,8 +15,6 @@ const Home: NextPage<HomeProps> = (props) => {
   const { ssrPokemon } = props;
   const dispatch = useDispatch<AppDispatch>();
 
-  const pokemon = useSelector(getInitialPokemon);
-
   const capitalizeFirstLetter = (str: string) => {
     return str.charAt(0).toUpperCase() + str.slice(1);
   };
@@ -26,39 +22,15 @@ const Home: NextPage<HomeProps> = (props) => {
   useEffect(() => {
     if (ssrPokemon && ssrPokemon.length > 0) {
       dispatch(setInitialPokemon(ssrPokemon));
-    } else {
-      dispatch(fetchInitialPokemon());
     }
   }, []);
 
-  // Handles the initial loading of the app
-  if (ssrPokemon && ssrPokemon.length > 0) {
-    return (
-      <>
-        <div className={styles.container}>
-          <h1 className='font-bold text-3xl mb-2'>Here we go!</h1>
-          {/* {pokemon && pokemon.map((p) => <p key={p.name}>{p.name}</p>)} */}
-          {ssrPokemon &&
-            ssrPokemon.map((p) => (
-              <Link
-                className='block underline w-40'
-                key={p.name}
-                href={`/${p.name}`}>
-                {capitalizeFirstLetter(p.name)}
-              </Link>
-            ))}
-        </div>
-      </>
-    );
-  }
-
-  // Handles Client side routing changes
   return (
     <>
       <div className={styles.container}>
         <h1 className='font-bold text-3xl mb-2'>Here we go!</h1>
-        {pokemon &&
-          pokemon.map((p) => (
+        {ssrPokemon &&
+          ssrPokemon.map((p) => (
             <Link
               className='block underline w-40'
               key={p.name}
@@ -71,18 +43,29 @@ const Home: NextPage<HomeProps> = (props) => {
   );
 };
 
-Home.getInitialProps = async (ctx) => {
+//Todo: See if we can use store with getServerSideProps instead of getInitialProps
+
+//! We want to see if we can set selectors on the server rather than the client
+//build store in server
+//selectors should be available within component by useSelector
+//https://redux-toolkit.js.org/rtk-query/usage/server-side-rendering
+
+export const getServerSideProps = async (ctx) => {
   const { req } = ctx;
   if (!req) {
     return {
-      ssrPokemon: [],
+      props: {
+        ssrPokemon: [],
+      },
     };
   }
 
   const ssrPokemon = await getAllPokemon();
 
   return {
-    ssrPokemon,
+    props: {
+      ssrPokemon,
+    },
   };
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,10 +7,12 @@ import Link from 'next/link';
 import { getAllPokemon } from '../apiCalls';
 import { AppDispatch } from '../store/store';
 
+// Interfaces
 interface HomeProps {
   ssrPokemon?: { name: string; url: string }[];
 }
 
+// Functional Component- Default export
 const Home: NextPage<HomeProps> = (props) => {
   const { ssrPokemon } = props;
   const dispatch = useDispatch<AppDispatch>();
@@ -43,13 +45,7 @@ const Home: NextPage<HomeProps> = (props) => {
   );
 };
 
-//Todo: See if we can use store with getServerSideProps instead of getInitialProps
-
-//! We want to see if we can set selectors on the server rather than the client
-//build store in server
-//selectors should be available within component by useSelector
-//https://redux-toolkit.js.org/rtk-query/usage/server-side-rendering
-
+// Server Side Rendering Logic
 export const getServerSideProps = async (ctx) => {
   const { req } = ctx;
   if (!req) {
@@ -59,6 +55,13 @@ export const getServerSideProps = async (ctx) => {
       },
     };
   }
+
+  //Todo: See if we can use store with getServerSideProps instead of getInitialProps
+
+  //! We want to see if we can set selectors on the server rather than the client
+  //build store in server
+  //selectors should be available within component by useSelector
+  //https://redux-toolkit.js.org/rtk-query/usage/server-side-rendering
 
   const ssrPokemon = await getAllPokemon();
 

--- a/store/actions.ts
+++ b/store/actions.ts
@@ -1,8 +1,9 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
-import { PokemonBase, setInitialPokemon } from './pokemonSlice';
+import { setInitialPokemon } from './pokemonSlice';
 import { pokemonApiBaseURL } from '../apiCalls';
 import { setPokemonInfo } from './pokemonInfoSlice';
+import { PokemonBase } from '../types/types';
 
 export const fetchInitialPokemon = createAsyncThunk<void, undefined>(
   'fetchInitialPokemon',

--- a/store/pokemonInfoSlice.ts
+++ b/store/pokemonInfoSlice.ts
@@ -16,7 +16,7 @@ const initialState: InitialState = {
   image: '',
   name: '',
   types: [],
-  stats: null,
+  stats: [],
 };
 
 const pokemonInfoSlice = createSlice({

--- a/store/pokemonSlice.ts
+++ b/store/pokemonSlice.ts
@@ -1,13 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { PokemonBase } from '../types/types';
 
 interface InitialState {
   allPokemon: PokemonBase[];
-}
-
-export interface PokemonBase {
-  name: string;
-  url: string;
-  id: number;
 }
 
 const initialState: InitialState = {

--- a/store/selectors.ts
+++ b/store/selectors.ts
@@ -1,23 +1,5 @@
-import { PokemonBase } from './pokemonSlice';
+import { AppState } from '../types/types';
 import { createSelector } from '@reduxjs/toolkit';
-
-export interface StatsType {
-  type: {
-    base_stat: number;
-    stat: string;
-  }[];
-}
-interface AppState {
-  pokemonSlice: {
-    allPokemon: PokemonBase[];
-  };
-  pokemonInfoSlice: {
-    image: string;
-    name: string;
-    types: string[];
-    stats: StatsType[];
-  };
-}
 
 // PokemonSlice Selectors
 const getPokemon = (state: AppState) => state.pokemonSlice;

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,0 +1,40 @@
+export interface AppState {
+  pokemonSlice: {
+    allPokemon: PokemonBase[];
+  };
+  pokemonInfoSlice: {
+    image: string;
+    name: string;
+    types: Type[];
+    stats: Stat[];
+  };
+}
+
+export interface PokemonInfo {
+  image: string;
+  name: string;
+  stats: Stat[];
+  types: Type[];
+}
+
+export interface Stat {
+  base_stat: number;
+  effort: number;
+  stat: {
+    name: string;
+    url: string;
+  };
+}
+
+export interface Type {
+  type: {
+    name: string;
+    url: string;
+  };
+}
+
+export interface PokemonBase {
+  name: string;
+  url: string;
+  id: number;
+}


### PR DESCRIPTION
## Description: 

I went from `getInitialProps` to `getServerSideProps.` In doing so, there is no longer a need to handle data coming at the initial load time apart from client-side set info. It calls the server at the time of the request rather than in the initial build time.

## Benefit:
Doing so makes the app easier to manage as it ensures props availability upon load. 